### PR TITLE
docs: :memo: (#422) add missing GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/actions_template_sync.yml
+++ b/.github/workflows/actions_template_sync.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   repo-sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       # To use this repository's private action, you must check out the repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ jobs:
   call_test_all:
     uses: ./.github/workflows/test_all.yml
     secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
   call_release_please:
     needs:
       - call_shellcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ on:
 jobs:
   test-implementation-job:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -12,12 +12,24 @@ jobs:
   call_test_hooks:
     uses: ./.github/workflows/test_hooks.yml
     secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
   call_test_ssh_gitlab:
     uses: ./.github/workflows/test_ssh_gitlab.yml
     secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
   call_test_ssh:
     uses: ./.github/workflows/test_ssh.yml
     secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
   call_test:
     uses: ./.github/workflows/test.yml
     secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/test_hooks.yml
+++ b/.github/workflows/test_hooks.yml
@@ -11,7 +11,9 @@ on:
 jobs:
   test-implementation-job:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout

--- a/.github/workflows/test_ssh.yml
+++ b/.github/workflows/test_ssh.yml
@@ -11,7 +11,9 @@ on:
 jobs:
   test-implementation-job:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout

--- a/.github/workflows/test_ssh_gitlab.yml
+++ b/.github/workflows/test_ssh_gitlab.yml
@@ -11,7 +11,9 @@ on:
 jobs:
   test-implementation-job:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # To use this repository's private action, you must check out the repository
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -85,12 +85,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.CUSTOM_GITHUB_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: actions-template-sync
         uses: AndreasAugustin/actions-template-sync@v1.1.8
+        permissions:
+          content: write
+          pull-requests: write
         with:
-          github_token: ${{ secrets.CUSTOM_GITHUB_PAT }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: <owner/repo>
           upstream_branch: <target_branch> # defaults to main
           pr_labels: <label1>,<label2>[,...] # optional, no default
@@ -155,12 +158,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.CUSTOM_GITHUB_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: actions-template-sync
         uses: AndreasAugustin/actions-template-sync@v1.1.8
+        permissions:
+          content: write
+          pull-requests: write
         with:
-          github_token: ${{ secrets.CUSTOM_GITHUB_PAT }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: ${{ secrets.SOURCE_REPO_PATH }} # <owner/repo>, should be within secrets
           upstream_branch: ${{ secrets.TARGET_BRANCH }} #<target_branch> # defaults to main
           pr_labels: <label1>,<label2>[,...] # optional, no default

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ on:
 jobs:
   repo-sync:
     runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       # To use this repository's private action, you must check out the repository
@@ -89,9 +93,6 @@ jobs:
 
       - name: actions-template-sync
         uses: AndreasAugustin/actions-template-sync@v1.1.8
-        permissions:
-          content: write
-          pull-requests: write
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: <owner/repo>
@@ -152,6 +153,10 @@ It is also possible to use a different git provider, e.g. GitLab.
 jobs:
   repo-sync:
     runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       # To use this repository's private action, you must check out the repository
@@ -162,9 +167,6 @@ jobs:
 
       - name: actions-template-sync
         uses: AndreasAugustin/actions-template-sync@v1.1.8
-        permissions:
-          content: write
-          pull-requests: write
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           source_repo_path: ${{ secrets.SOURCE_REPO_PATH }} # <owner/repo>, should be within secrets


### PR DESCRIPTION
# Description

Hi @dotdc .

Sorry for the inconvenience.
The permission part was definitely missing within the examples. The default permissions for workflows is readonly.
You have 2 options to define those permissions:
- general within repo action settings
- per workflow within yaml https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

decided to use least privilege for the examples.

Hope this PR will solve the issues. 

**Remarks**
- Did not want to interfere with your changes -> created this PR instead of changing your PR HEAD
- AFAIK you still need a PAT if you like to change a workflow definition file. At least I did not find a solution with GITHUB_TOKEN. https://github.com/AndreasAugustin/actions-template-sync/issues/424

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
